### PR TITLE
Another typo in quest enemy category.

### DIFF
--- a/mods/alpha_demo/maps/averguard_academy.txt
+++ b/mods/alpha_demo/maps/averguard_academy.txt
@@ -558,7 +558,7 @@ category=zombie_normal
 [enemy]
 type=enemy
 location=5,91,1,1
-category=rofessor_langlier
+category=professor_langlier
 direction=1
 wander_radius=0
 


### PR DESCRIPTION
Professor Langlier couldn't be fined in Aveguard Academy. The enemy category contains typo.