### PR TITLE
Adding special behaviour to ranged enemies

### DIFF
--- a/mods/empyrean_campaign/enemies/lvl10_skeleton_sharpshooter.txt
+++ b/mods/empyrean_campaign/enemies/lvl10_skeleton_sharpshooter.txt
@@ -32,4 +32,30 @@ cooldown=1575ms
 # loot
 loot=loot/level_10.txt
 
+### Section of ranged units behaviour
 
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=1
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 17
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+#power=melee,164,5
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,196,80

--- a/mods/empyrean_campaign/enemies/lvl2_goblin_spearman.txt
+++ b/mods/empyrean_campaign/enemies/lvl2_goblin_spearman.txt
@@ -10,10 +10,6 @@ xp=4
 stat=hp,75
 speed=2.7
 turn_delay=400ms
-chance_pursue=15
-
-power=melee,164,5
-power=ranged,165,3
 
 stat=accuracy,90
 stat=avoidance,15
@@ -30,3 +26,29 @@ stat=absorb_max,2
 # loot
 loot=loot/level_2.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=7
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 12	
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#melee_range = 1.125 #it's set in fantasycore files
+power=melee,164,10
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,165,30

--- a/mods/empyrean_campaign/enemies/lvl2_skeleton_archer.txt
+++ b/mods/empyrean_campaign/enemies/lvl2_skeleton_archer.txt
@@ -10,10 +10,7 @@ xp=4
 stat=hp,75
 speed=3.2
 turn_delay=200ms
-chance_pursue=5
 
-power=melee,164,5
-power=ranged,171,3
 passive_powers=185
 
 stat=accuracy,100
@@ -32,4 +29,29 @@ cooldown=1775ms
 # loot
 loot=loot/level_2.txt
 
+### Section of ranged units behaviour
 
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=5
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 15	
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#melee_range = 1.125 #it's set in fantasycore files
+power=melee,164,10
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,171,34

--- a/mods/empyrean_campaign/enemies/lvl3_skeleton_fire_mage.txt
+++ b/mods/empyrean_campaign/enemies/lvl3_skeleton_fire_mage.txt
@@ -11,10 +11,6 @@ stat=hp,90
 speed=3.4
 turn_delay=200ms
 
-chance_pursue=5
-
-power=melee,164,5
-power=ranged,173,3
 passive_powers=185
 
 stat=accuracy,100
@@ -37,3 +33,29 @@ cooldown=1550ms
 # loot
 loot=loot/level_3.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=3
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 15	
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#melee_range = 1.125 #it's set in fantasycore files
+power=melee,164,1
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,173,30

--- a/mods/empyrean_campaign/enemies/lvl3_skeleton_ice_mage.txt
+++ b/mods/empyrean_campaign/enemies/lvl3_skeleton_ice_mage.txt
@@ -11,10 +11,6 @@ stat=hp,90
 speed=3.4
 turn_delay=200ms
 
-chance_pursue=5
-
-power=melee,164,5
-power=ranged,172,3
 passive_powers=185
 
 stat=accuracy,100
@@ -37,3 +33,29 @@ cooldown=1550ms
 # loot
 loot=loot/level_3.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=5
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 12	
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#melee_range = 1.125 #it's set in fantasycore files
+power=melee,164,2
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,172, 30

--- a/mods/empyrean_campaign/enemies/lvl3_skeleton_sniper.txt
+++ b/mods/empyrean_campaign/enemies/lvl3_skeleton_sniper.txt
@@ -10,10 +10,7 @@ xp=8
 stat=hp,100
 speed=3.4
 turn_delay=200ms
-chance_pursue=5
 
-power=melee,164,5
-power=ranged,171,3
 passive_powers=185
 
 stat=accuracy,105
@@ -32,4 +29,30 @@ cooldown=1750ms
 # loot
 loot=loot/level_3.txt
 
+### Section of ranged units behaviour
 
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=3
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 15
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164,5
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,171,50

--- a/mods/empyrean_campaign/enemies/lvl4_cid.txt
+++ b/mods/empyrean_campaign/enemies/lvl4_cid.txt
@@ -10,10 +10,6 @@ stat=hp,460
 speed=4.4
 turn_delay=200ms
 
-chance_pursue=15
-
-power=melee,164,5
-power=ranged,176,15
 passive_powers=185
 
 stat=accuracy,105
@@ -40,3 +36,31 @@ loot=loot/level_4.txt
 
 # Dark Steppers
 loot=94,1
+
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=15
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 25
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 12
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164,5
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,176,50

--- a/mods/empyrean_campaign/enemies/lvl4_geno.txt
+++ b/mods/empyrean_campaign/enemies/lvl4_geno.txt
@@ -10,10 +10,6 @@ stat=hp,460
 speed=4.4
 turn_delay=200ms
 
-chance_pursue=15
-
-power=melee,164,5
-power=ranged,174,15
 passive_powers=185
 
 stat=accuracy,105
@@ -40,3 +36,31 @@ loot=loot/level_4.txt
 
 # Blood Tunic
 loot=93,1
+
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=15
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 25
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 12
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164,5
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,174,50

--- a/mods/empyrean_campaign/enemies/lvl5_antlion_freezer.txt
+++ b/mods/empyrean_campaign/enemies/lvl5_antlion_freezer.txt
@@ -11,11 +11,6 @@ stat=hp,140
 speed=4.8
 turn_delay=200ms
 
-chance_pursue=10
-
-power=melee,164,1
-power=ranged,172,5
-
 stat=accuracy,105
 stat=avoidance,45
 stat=poise,22
@@ -36,3 +31,30 @@ cooldown=1500ms
 # loot
 loot=loot/level_5.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=5
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 13
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 10
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164,30
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,172,50

--- a/mods/empyrean_campaign/enemies/lvl5_goblin_hurler.txt
+++ b/mods/empyrean_campaign/enemies/lvl5_goblin_hurler.txt
@@ -10,10 +10,6 @@ xp=32
 stat=hp,150
 speed=3.3
 turn_delay=400ms
-chance_pursue=15
-
-power=melee,164,5
-power=ranged,165,3
 
 stat=accuracy,105
 stat=avoidance,30
@@ -30,3 +26,30 @@ stat=absorb_max,5
 # loot
 loot=loot/level_5.txt
 
+
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=7
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 12	
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#melee_range = 1.125 #it's set in fantasycore files
+power=melee,164,10
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,165,30

--- a/mods/empyrean_campaign/enemies/lvl6_antlion_frostbite.txt
+++ b/mods/empyrean_campaign/enemies/lvl6_antlion_frostbite.txt
@@ -1,4 +1,5 @@
 INCLUDE enemies/base/antlion_ice.txt
+INCLUDE enemies/presets/ranged_antlion.txt
 
 name=Frostbite Antlion
 level=6
@@ -10,11 +11,6 @@ xp=64
 stat=hp,165
 speed=5
 turn_delay=200ms
-
-chance_pursue=10
-
-power=melee,164,1
-power=ranged,172,5
 
 stat=accuracy,110
 stat=avoidance,50
@@ -36,3 +32,30 @@ cooldown=1475ms
 # loot
 loot=loot/level_6.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=5
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 13
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 10
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164,30
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,172,50

--- a/mods/empyrean_campaign/enemies/lvl6_antlion_spitter.txt
+++ b/mods/empyrean_campaign/enemies/lvl6_antlion_spitter.txt
@@ -11,11 +11,6 @@ stat=hp,165
 speed=5
 turn_delay=200ms
 
-chance_pursue=10
-
-power=melee,164,1
-power=ranged,173,5
-
 stat=accuracy,110
 stat=avoidance,50
 stat=poise,25
@@ -36,3 +31,30 @@ cooldown=1475ms
 # loot
 loot=loot/level_6.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=5
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 13
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 10
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164,30
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,172,50

--- a/mods/empyrean_campaign/enemies/lvl6_skeleton_frost_mage.txt
+++ b/mods/empyrean_campaign/enemies/lvl6_skeleton_frost_mage.txt
@@ -11,11 +11,6 @@ stat=hp,165
 speed=4
 turn_delay=200ms
 
-chance_pursue=5
-
-power=melee,164,1
-power=melee,183,5
-power=ranged,172,3
 passive_powers=185
 
 stat=accuracy,115
@@ -38,3 +33,31 @@ cooldown=1475ms
 # loot
 loot=loot/level_6.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=1
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 13
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164,1
+power=melee,183,10
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,172,50

--- a/mods/empyrean_campaign/enemies/lvl7_wyvern.txt
+++ b/mods/empyrean_campaign/enemies/lvl7_wyvern.txt
@@ -28,5 +28,3 @@ cooldown=1450ms
 
 # loot
 loot=loot/level_7.txt
-
-

--- a/mods/empyrean_campaign/enemies/lvl7_wyvern_fire.txt
+++ b/mods/empyrean_campaign/enemies/lvl7_wyvern_fire.txt
@@ -10,10 +10,6 @@ xp=128
 stat=hp,210
 speed=4.7
 turn_delay=200ms
-chance_pursue=5
-
-power=melee,164,1
-power=ranged,173,5
 
 stat=accuracy,125
 stat=avoidance,55
@@ -34,4 +30,30 @@ cooldown=1650ms
 # loot
 loot=loot/level_7.txt
 
+### Section of ranged units behaviour
 
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=1
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 15
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164, 5
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,173,50

--- a/mods/empyrean_campaign/enemies/lvl7_wyvern_ice.txt
+++ b/mods/empyrean_campaign/enemies/lvl7_wyvern_ice.txt
@@ -10,10 +10,6 @@ xp=128
 stat=hp,210
 speed=4.7
 turn_delay=200ms
-chance_pursue=5
-
-power=melee,164,1
-power=ranged,172,5
 
 stat=accuracy,125
 stat=avoidance,55
@@ -34,4 +30,30 @@ cooldown=1650ms
 # loot
 loot=loot/level_7.txt
 
+### Section of ranged units behaviour
 
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=1
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 15
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,164, 5
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,172,50

--- a/mods/empyrean_campaign/enemies/lvl9_antlion_sprayer.txt
+++ b/mods/empyrean_campaign/enemies/lvl9_antlion_sprayer.txt
@@ -11,11 +11,6 @@ stat=hp,240
 speed=5.6
 turn_delay=200ms
 
-chance_pursue=10
-
-power=melee,191,2
-power=ranged,191,10
-
 stat=accuracy,125
 stat=avoidance,65
 stat=poise,34
@@ -33,4 +28,32 @@ cooldown=1400ms
 
 # loot
 loot=loot/level_9.txt
+
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=7
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 13
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 10
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+power=melee,191,15
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,191,60
 

--- a/mods/empyrean_campaign/enemies/lvl9_goblin_hunter.txt
+++ b/mods/empyrean_campaign/enemies/lvl9_goblin_hunter.txt
@@ -10,10 +10,6 @@ xp=512
 stat=hp,250
 speed=4.1
 turn_delay=400ms
-chance_pursue=15
-
-power=melee,164,5
-power=ranged,165,3
 
 stat=accuracy,125
 stat=avoidance,50
@@ -30,3 +26,30 @@ stat=absorb_max,9
 # loot
 loot=loot/level_9.txt
 
+### Section of ranged units behaviour
+
+#It cause shooter to come closer, sometimes.
+#Not only if player is out of range, but it's realistic enough --- real shooter would like to come closer, to aim better ;)
+chance_pursue=7
+
+#That chance is enough. It can vary, but works nice, as for me
+chance_flee= 20
+
+#Just copied that stats from necro-minotaur, assuming they are default
+flee_duration=3s
+flee_cooldown=1s
+
+#With this setting enemy do shooting from visible area.
+#Remember: (threat_range / 2) is hardcoded in standart-behaviour (as for 15.09.2016) as range, closer than which fleeng enemies can't come to hero.
+#I was trying different values, and can say, that 10 is surely less than needed (10/2=5 -- very small range)
+#and 20 is surely more than needed (skeletons starts shooting even if u do not see them. also it's hard to catch them. really hard)
+threat_range = 14
+
+#However, if player came close enough to skeleton, he will not run forever, but will take a fight as a man
+#That values are default, so I assume, we do not need them here (but keep in mind -- final config needs that stats)
+#melee_range = 1.125
+#power=melee,164,5
+
+#Following is maximised to let shooter not only flee from one side to another.
+#Did not tested lower values, maybe it can be decreased
+power=ranged,165,80


### PR DESCRIPTION
Different behaviour provided to different enemies.
Goblins are not clever enough, so they have high chance to attack melee, and skeletons have very low chance for it, for example; Archers and mages keep far from player, while goblins and antlions can't do it; etc.

It's about #518 issue.