### PR TITLE
Add appdata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,8 @@ install(DIRECTORY
 install(DIRECTORY
   "${CMAKE_CURRENT_SOURCE_DIR}/mods/centered_statbars"
   DESTINATION ${DATADIR}/mods)
+
+# installing appdata
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/distribution/org.flarerpg.Flare.appdata.xml"
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/appdata)

--- a/distribution/org.flarerpg.Flare.appdata.xml
+++ b/distribution/org.flarerpg.Flare.appdata.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+	<id>org.flarerpg.Flare</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<!--FIXME: convert to an SPDX license string-->
+	<project_license>GPL-3.0-or-later AND CC-BY-SA-3.0</project_license>
+	<name>Flare: Empyrean Campaign</name>
+	<description>
+		<p>Flare is an open source, 2D action RPG licensed under the GPL3 license. Its game play can be likened to the games in the Diablo series.</p>
+		<p>The Empyrean Campaign is a game made by the Flare team. The story begins with the player being exiled from their homeland of Empyrean, resulting in them embarking on a quest to regain entry. This journey takes the player through many regions, with plenty of side quests along the way.</p>
+	</description>
+	<url type="homepage">http://flarerpg.org/</url>
+	<releases>
+		<release date="2018-03-12" version="1.0" />
+	</releases>
+	<screenshots>
+		<screenshot type="default">
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_1.jpg</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_2.jpg</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_3.jpg</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_4.jpg</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_5.jpg</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_6.jpg</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_7.jpg</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">http://flarerpg.org/wp-content/uploads/2018/03/empyrean_8.jpg</image>
+		</screenshot>
+	</screenshots>
+	<developer_name>Clint Bellanger and Contributors</developer_name>
+	<!--FIXME: where to report bugs for the application-->
+	<url type="bugtracker">https://github.com/clintbellanger/flare-game/issues</url>
+	<!--FIXME: where on the internet users can find help-->
+	<url type="help">https://opengameart.org/forums/flare</url>
+	<!--FIXME: this is optional, but recommended-->
+	<!--<update_contact></update_contact>-->
+</component>


### PR DESCRIPTION
This is required for Gnome Software, KDE Discover and Flathub. The metadata license should be one of      

* FSFAP
* CC0-1.0
* CC-BY-3.0
* CC-BY-SA-3.0
* GFDL-1.3
* MIT

Ideally, it would be CC0-1.0